### PR TITLE
Bugfix for error in domain plotting when deposition spreads over pole.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,8 @@ local/
 # Default test data link
 data
 
-# Plot test directory
-test_preset_plots/
-plot_*/
+# Non-permanent data, e.g. test output
+scratch/
 
 # Batch processing log files
 log/

--- a/src/pyflexplot/plotting/coord_trans.py
+++ b/src/pyflexplot/plotting/coord_trans.py
@@ -134,12 +134,13 @@ class CoordinateTransformer:
         # pylint: disable=E0633  # unpacking-non-sequence
         x_geo, y_geo = self.axes_to_geo(x, y)
         x, y = self.geo_to_map(x_geo, y_geo)
+
         if (
             isinstance(self.proj_map, PlateCarree)
             and not isinstance(x, float)
             and len(x) == 2
-            and np.isclose(x[0], x[1])
-            and np.isclose(np.abs(x[0]), 180)
+            and np.isclose(x[0], x[1], atol=0.5)
+            and np.isclose(np.abs(x[0]), 180, atol=0.5)
         ):
             # Fix edge case where lon range (-180, 180) is turned into (-180, -180)
             # during the transformation


### PR DESCRIPTION
The "cloud" domain is determined erroneously as x_geo=[-180.12517385 -179.87482615]; y_geo=[-90.  90.]. I added a (larger than default) tolerance in numpy.isclose to catch the problem in x_geo. y_geo howerver remains too large, and x_geo should not assume these values in the first place. So this is only a workaround for a deeper problem.