### PR TITLE
Fix upload of shapefiles

### DIFF
--- a/src/pyflexplot/cli/main.py
+++ b/src/pyflexplot/cli/main.py
@@ -184,8 +184,8 @@ def main(
             os.rmdir(dir_path)
 
     if open_cmd:
-        log(vbs=f"open {len(remaining_paths)} plots:")
-        open_plots(open_cmd, remaining_paths, dry_run)
+        log(vbs=f"open {len(all_out_file_paths)} plots:")
+        open_plots(open_cmd, all_out_file_paths, dry_run)
 
     return 0
 

--- a/src/pyflexplot/cli/main.py
+++ b/src/pyflexplot/cli/main.py
@@ -160,7 +160,7 @@ def main(
                 log(dbg=f"remove {path}")
                 Path(path).unlink()
 
-    items_in_dest = [file for file in Path(dest_dir).iterdir() if file.is_file()]
+    items_in_dest = [str(file) for file in Path(dest_dir).iterdir() if file.is_file()]
 
     if s3_dest:
         bucket_name, _, _ = split_s3_uri(s3_dest)

--- a/src/pyflexplot/cli/main.py
+++ b/src/pyflexplot/cli/main.py
@@ -160,7 +160,7 @@ def main(
                 log(dbg=f"remove {path}")
                 Path(path).unlink()
 
-    remaining_paths = [item for item in all_out_file_paths if item not in redundant_shape_files]
+    items_in_dest = [file for file in Path(dest_dir).iterdir() if file.is_file()]
 
     if s3_dest:
         bucket_name, _, _ = split_s3_uri(s3_dest)
@@ -169,7 +169,7 @@ def main(
         bucket = CONFIG.main.aws.s3.output
         bucket.name = bucket_name
         upload_outpaths_to_s3(
-            remaining_paths,
+            items_in_dest,
             setup_groups[0]._setups[0].model,
             bucket=bucket)
 


### PR DESCRIPTION
It turns out `redundant_shape_files` only contains anything if `--merge-shapefiles` flag is used (which we are not using) so the previous PR https://github.com/MeteoSwiss-APN/pyflexplot/pull/55 did not help the issue. `all_out_file_paths` contains still files which actually do not exist anymore since the .shp files are zipped. This is unaddressed. I assume that the `open_plots` call may not work because of this? https://github.com/MeteoSwiss-APN/pyflexplot/blob/main/src/pyflexplot/cli/main.py#L186-L189

This PR ensures that only existing files are uploaded by listing the contents of destination directory `items_in_dest`, and passing this to the S3 function `upload_outpaths_to_s3`