### PR TITLE
Bump patch version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyflexplot"
-version = "2.2.3"
+version = "2.2.4"
 description = "PyFlexPlot - Visualize and post-process FLEXPART dispersion simulation results stored in NetCDF format"
 authors = ["Stefan Ruedisuehli <stefan.ruedisuehli@env.ethz.ch>", "Pirmin Kaufmann <pirmin.kaufmann@meteoswiss.ch>"]
 packages = [


### PR DESCRIPTION
To test a new installation procedure at CSCS in operations, we would like to patch the release version from 2.2.3 to 2.2.4. This includes a couple of recent commits which only change the Jenkinsfile. The commit is already tagged, and the difference can be seen here: https://github.com/MeteoSwiss-APN/pyflexplot/compare/2.2.3...2.2.4

@pirmink can you comment on whether this is OK for you?